### PR TITLE
Eliminate need to manually install p5 as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "p5-svelte",
-  "version": "2.1.0",
+  "version": "2.2.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.0",
+      "version": "2.2.0-0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "description": "A p5 component to seamlessly toss into existing Svelte projects",
-  "version": "2.1.0",
+  "version": "2.2.0-0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tonyketcham/p5-svelte.git"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "p5": "^1.1.9",
     "rollup": "^2.0.0",
     "rollup-plugin-svelte": "^6.0.0",
-    "svelte": "^3.0.0"
+    "svelte": "^3.0.0",
+    "p5": "^1.1.9"
+  },
+  "peerDependencies": {
+    "p5": "*"
   },
   "keywords": [
     "svelte"


### PR DESCRIPTION
This update establishes p5 as a peerDependency and thus only `yarn add p5-svelte` or `npm install p5-svelte` is needed