### PR TITLE
Add p5 types to the component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: Build CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br>
 
 <div align="center">
-<img src="https://github.com/tonyketcham/p5-svelte/raw/master/static/logo.svg" alt="p5-svelte logo" width="80" />
+<img src="https://github.com/tonyketcham/p5-svelte/raw/main/static/logo.svg" alt="p5-svelte logo" width="80" />
 </div>
 
 <h1 align="center">p5-Svelte</h1>
@@ -17,7 +17,11 @@ Trying to get <a href="https://p5js.org/">p5</a> up and running in [Svelte](http
 The API is super simple; you get a <code>P5</code> component which accepts a <code>sketch</code> prop. You can make use of Svelte's reactivity system to bind props or params within your p5 sketch just as you would with regular Svelte! You can even have multiple p5 components per page without any scoping issues!
 
 <p align="center">
-<a href="https://svelte.dev/repl/c5fd1d8347cd4e47afe0e519aedbb3a5?version=3.31.2" target="_blank">🌱 Simple Demo</a>
+	<a href="https://svelte.dev/repl/c5fd1d8347cd4e47afe0e519aedbb3a5?version=3.31.2" target="_blank">📘 Docs + Examples</a>
+</p>
+
+<p align="center">
+	<a href="https://svelte.dev/repl/c5fd1d8347cd4e47afe0e519aedbb3a5?version=3.31.2" target="_blank">🌱 Simple Demo</a>
 </p>
 
 ## Usage
@@ -70,13 +74,18 @@ Now add `p5-svelte` to your project (ex. `src/App.svelte`):
 
 ### Output:
 
-![using Svelte's reactivity system to bind parameters to a p5 sketch](https://dev-to-uploads.s3.amazonaws.com/i/ajyz894enhdgdvot441x.gif)
+<div align="center">
+	<img src="https://dev-to-uploads.s3.amazonaws.com/i/ajyz894enhdgdvot441x.gif" alt="using Svelte's reactivity system to bind parameters to a p5 sketch" />
+</div>
 
-<!-- <img align="right" src="https://dev-to-uploads.s3.amazonaws.com/i/ajyz894enhdgdvot441x.gif" alt="using Svelte's reactivity system to bind parameters to a p5 sketch" width="265" height="265" /> -->
+## Available Props
 
-**It's that easy! 😃**
-
-<br>
+| prop             | description                                                                                                                           | type          | default             | required? |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------- | --------- |
+| `sketch`         | Your p5 sketch in instance mode                                                                                                       | `Sketch`      | `undefined`         | yes       |
+| `target`         | An HTML element/node to mount the p5 canvas onto giving you full control of the parent wrapper that p5 renders a canvas as a child to | `HTMLElement` | `undefined`         | no        |
+| `parentDivStyle` | A p5 sketch instance -- you likely don't need this but this allows you to seed. Note: does nothing when paired with a `target`        | `string`      | `'display: block;'` | no        |
+| `debug`          | Logs everything about the p5 instance to the console for debugging purposes                                                           | `boolean`     | `false`             | no        |
 
 ## p5.js instance mode
 
@@ -101,3 +110,15 @@ Emits a reference to the DOM element target which the p5 instance mounts to.
 ### `init`
 
 This event fires on init of the p5 project instance, emitting a reference to that p5 project instance object.
+
+## TypeScript support + Intellisense
+
+`p5-svelte` exposes a `Sketch` type representing the p5 sketch in instance mode. This gives your editor prying eyes into p5's type system, supports autocomplete, and inline documentation of all the p5 goodies to make your life a little easier.
+
+### 😤 Before
+
+https://user-images.githubusercontent.com/43280336/161372626-32634e5b-37b1-4f56-b708-518200b1021f.mov
+
+### 🧙‍♀️ After
+
+https://user-images.githubusercontent.com/43280336/161373024-01c1a01d-b9ea-4ce4-8787-c42329a50ff6.mov

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `<P5/>` component emits a few events you can listen to.
 
 Emits a reference to the DOM element target which the p5 instance mounts to.
 
-### `init`
+### `instance`
 
 This event fires on init of the p5 project instance, emitting a reference to that p5 project instance object.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^1.0.0-next.29",
 		"@sveltejs/kit": "1.0.0-next.304",
+		"@types/p5": "^1.4.2",
 		"@typescript-eslint/eslint-plugin": "^4.33.0",
 		"@typescript-eslint/parser": "^4.33.0",
 		"@zerodevx/svelte-toast": "^0.6.3",
@@ -58,7 +59,8 @@
 		"typescript": "^4.6.2"
 	},
 	"peerDependencies": {
-		"p5": "^1.4.0"
+		"p5": "^1.4.0",
+		"@types/p5": "^1.4.2"
 	},
 	"type": "module",
 	"svelte": "index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "p5-svelte",
 	"description": "A component for easily using p5 sketches in Svelte. Allows using Svelte's reactivity system in p5.",
-	"version": "3.0.3",
+	"version": "3.1.0",
 	"keywords": [
 		"svelte",
 		"svelte-component",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "p5-svelte",
 	"description": "A component for easily using p5 sketches in Svelte. Allows using Svelte's reactivity system in p5.",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"keywords": [
 		"svelte",
 		"svelte-component",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@sveltejs/adapter-static': ^1.0.0-next.29
   '@sveltejs/kit': 1.0.0-next.304
+  '@types/p5': ^1.4.2
   '@typescript-eslint/eslint-plugin': ^4.33.0
   '@typescript-eslint/parser': ^4.33.0
   '@zerodevx/svelte-toast': ^0.6.3
@@ -32,6 +33,7 @@ dependencies:
 devDependencies:
   '@sveltejs/adapter-static': 1.0.0-next.29
   '@sveltejs/kit': 1.0.0-next.304_svelte@3.46.4
+  '@types/p5': 1.4.2
   '@typescript-eslint/eslint-plugin': 4.33.0_148f60167662f80a92e29e1aea31e7a2
   '@typescript-eslint/parser': 4.33.0_eslint@8.10.0+typescript@4.6.2
   '@zerodevx/svelte-toast': 0.6.3
@@ -191,6 +193,10 @@ packages:
 
   /@types/node/17.0.21:
     resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
+    dev: true
+
+  /@types/p5/1.4.2:
+    resolution: {integrity: sha512-tzJ2PdmeXlX8tidbA1/pQEhs0MHVWam0K4ux5ri0GrZXhBU3QrpTpSVzNaBDuo6KheryHdH8wR82x1nPvxo42g==}
     dev: true
 
   /@types/parse-json/4.0.0:

--- a/src/app.css
+++ b/src/app.css
@@ -24,8 +24,9 @@ article > * > section {
 }
 
 p > a {
-	@apply border-b-2 bg-gray-700 bg-opacity-40 border-p5/80 py-0.5 px-1 font-medium text-gray-50 tracking-wide hover:border-p5;
-	@apply transition-colors;
+	@apply border-b-2 bg-gray-700 bg-opacity-40 border-p5/80 py-0.5 px-1 font-medium text-gray-50 tracking-wide;
+	@apply hover:border-p5 hover:text-p5 focus:border-p5 focus:text-p5;
+	@apply motion-safe:transition-colors;
 }
 
 p {

--- a/src/app.css
+++ b/src/app.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+	--scrollbar-track-color: rgb(14, 14, 14);
+	--scrollbar-thumb-color: rgb(237 34 93 / 0.8);
+}
+
 html {
 	background: black;
 }
@@ -9,6 +14,46 @@ body {
 	color: white;
 }
 
+article.doc {
+	@apply flex flex-col space-y-3 max-w-[90ch];
+}
+
+article > section,
+article > * > section {
+	@apply space-y-3 pt-3;
+}
+
 p > a {
-	@apply bg-p5/80 py-0.5 px-1 rounded;
+	@apply border-b-2 bg-gray-700 bg-opacity-40 border-p5/80 py-0.5 px-1 font-medium text-gray-50 tracking-wide hover:border-p5;
+	@apply transition-colors;
+}
+
+p {
+	@apply py-0.5 text-gray-300 font-sans text-lg font-light opacity-90;
+}
+code {
+	@apply bg-gray-700/60 py-0.5 px-1 rounded border border-gray-600/30;
+}
+h3 {
+	@apply text-2xl pt-7 font-semibold text-p5/80 leading-6;
+}
+
+/* Works on Firefox */
+* {
+	scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
+}
+
+/* Works on Chrome, Edge, and Safari */
+*::-webkit-scrollbar {
+	@apply w-4;
+}
+
+*::-webkit-scrollbar-track {
+	background: var(--scrollbar-track-color);
+}
+
+*::-webkit-scrollbar-thumb {
+	background-color: var(--scrollbar-thumb-color);
+	border-radius: 20px;
+	border: 4px solid var(--scrollbar-track-color);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -33,10 +33,13 @@ p {
 	@apply py-0.5 text-gray-300 font-sans text-lg font-light opacity-90;
 }
 code {
-	@apply bg-gray-700/60 py-0.5 px-1 rounded border border-gray-600/30;
+	@apply bg-gray-700/60 py-0.5 px-1 rounded border border-gray-600/30 text-white;
 }
 h3 {
 	@apply text-2xl pt-7 font-semibold text-p5/80 leading-6;
+}
+h4 {
+	@apply text-xl pt-3 font-semibold text-p5/80 leading-6;
 }
 
 /* Works on Firefox */

--- a/src/components/CodeBlock.svelte
+++ b/src/components/CodeBlock.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 	import { HighlightAuto, HighlightSvelte } from 'svelte-highlight';
 	import blackMetalBathory from 'svelte-highlight/src/styles/synth-midnight-terminal-dark';
-	import { sketchExampleCode } from '../helpers/sketchExampleCode';
+	import { sketchExampleCode, type Language } from '../helpers/sketchExampleCode';
 	import { copyToClipboard } from '$helpers/clipboard';
 	import { toast } from '@zerodevx/svelte-toast';
 
 	export let code: string;
-	export let lang = 'svelte';
+	export let lang: Language = 'svelte';
 	export let isSketch = false;
 
 	let innerCode: HTMLElement;
+	$: isThisIshSvelte = ['svelte', 'svelte-ts'].includes(lang);
 
 	async function copy() {
 		const success = await copyToClipboard(innerCode.innerText);
@@ -27,8 +28,8 @@
 
 <div class="relative my-3 border border-p5/40 rounded-md overflow-hidden">
 	<div bind:this={innerCode}>
-		{#if lang === 'svelte'}
-			<HighlightSvelte code={isSketch ? sketchExampleCode(code) : code} />
+		{#if isThisIshSvelte}
+			<HighlightSvelte code={isSketch ? sketchExampleCode(code, lang) : code} />
 		{:else}
 			<HighlightAuto {code} />
 		{/if}
@@ -53,3 +54,9 @@
 		</svg>
 	</button>
 </div>
+
+<style>
+	:global(.hljs) {
+		@apply rounded-md border-0;
+	}
+</style>

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	export let header: string = '';
-	export let rootroute: string = '';
+	export let rootroute: string = '#';
 	export let elements: SidebarElement[] = [];
 
 	type SidebarElement = {
 		title: string;
 		route: string;
 	};
+
+	$: isClickable = rootroute !== '#' ? 'hover:bg-white/10' : '';
 </script>
 
 <aside class="sticky top-20 h-full mr-3 border-r border-white/10 w-56">
 	<div class="border-b border-white/10">
-		<a href={rootroute}>
-			<h1 class="py-2 m-2 text-lg text-center border border-white/10 rounded hover:bg-white/10">
+		<a sveltekit:prefetch href={rootroute}>
+			<h1 class="py-2 m-2 text-lg text-center border border-white/10 rounded {isClickable}">
 				{header}
 			</h1>
 		</a>

--- a/src/helpers/sketchExampleCode.ts
+++ b/src/helpers/sketchExampleCode.ts
@@ -1,9 +1,21 @@
-export function sketchExampleCode(sketch: string): string {
-	return `<script>
-  import P5 from "$lib/P5.svelte";
+export type Language = 'svelte' | 'svelte-ts' | 'ts' | 'js';
+
+export function sketchExampleCode(sketch: string, lang: Language): string {
+	if (lang === 'svelte') {
+		return `<script>
+  import P5 from "p5-svelte";
   
   const sketch = ${sketch}
 </script>
 
 <P5 {sketch} />`;
+	} else if (lang === 'svelte-ts') {
+		return `<script lang="ts">
+  import P5, { type Sketch } from "p5-svelte";
+
+  const sketch: Sketch = ${sketch}
+</script>
+
+<P5 {sketch} />`;
+	}
 }

--- a/src/lib/P5.svelte
+++ b/src/lib/P5.svelte
@@ -1,11 +1,13 @@
-<script>
+<script lang="ts">
 	import { onMount, createEventDispatcher } from 'svelte';
+	import type p5 from 'p5';
+	import type { Sketch } from '$lib/types';
 
-	// API properties
-	export let project = undefined;
-	export let target = undefined;
-	export let sketch = undefined;
-	export let parentDivStyle = 'display: block;';
+	// Component props
+	export let project: p5 = undefined;
+	export let target: HTMLElement = undefined;
+	export let sketch: Sketch = undefined;
+	export let parentDivStyle: string = 'display: block;';
 	export let debug = false;
 
 	// Event generation
@@ -23,7 +25,7 @@
 	 * Creates a reference for the p5 instance to render within
 	 * @param {HTMLElement} node
 	 */
-	function ref(node) {
+	function ref(node: HTMLElement) {
 		target = node;
 		return {
 			destroy() {
@@ -32,7 +34,10 @@
 		};
 	}
 
-	function augmentClasses(instance, classes) {
+	function augmentClasses<NativeClasses extends [string, Record<string, any>][]>(
+		instance: p5,
+		classes: NativeClasses
+	) {
 		classes.forEach(([key, value]) => (instance[key] = value));
 		return instance;
 	}
@@ -53,11 +58,13 @@
 			console.log('available p5 native classes', nativeClasses);
 		}
 
-		project = new p5((instance) => {
+		project = new p5((instance: p5) => {
 			instance = augmentClasses(instance, nativeClasses);
+
 			if (debug) {
 				console.log('p5 instance', instance);
 			}
+
 			// Set up a global object to capture this instance.
 			// @ts-ignore
 			window._p5Instance = instance;

--- a/src/lib/P5.svelte
+++ b/src/lib/P5.svelte
@@ -4,11 +4,12 @@
 	import type { Sketch } from '$lib/types';
 
 	// Component props
-	export let project: p5 = undefined;
 	export let target: HTMLElement = undefined;
 	export let sketch: Sketch = undefined;
 	export let parentDivStyle: string = 'display: block;';
 	export let debug = false;
+
+	let project: p5 = undefined;
 
 	// Event generation
 	const event = createEventDispatcher();
@@ -16,7 +17,7 @@
 		ref() {
 			event('ref', target);
 		},
-		init() {
+		instance() {
 			event('instance', project);
 		},
 	};
@@ -73,7 +74,7 @@
 
 		// Initial event dispatching
 		dispatch.ref();
-		dispatch.init();
+		dispatch.instance();
 	});
 </script>
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export { default as default } from './P5.svelte';
-export type { Sketch } from './types';
+export type { Sketch, p5 } from './types';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export { default as default } from './P5.svelte';
+export type { Sketch } from './types';

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,0 +1,8 @@
+import type p5 from 'p5';
+
+/**
+ * A closure representing a p5 sketch in [Instance Mode](https://github.com/processing/p5.js/wiki/Global-and-instance-mode).
+ *
+ * Within the closure you can set optional `preload()`, `setup()`, and/or `draw()` properties on the given p5 instance.
+ */
+export type Sketch = (sketch: p5) => void;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,13 +1,13 @@
 import type p5 from 'p5';
 
 /**
+ * A p5 instance, re-exported from `@types/p5`.
+ */
+export type p5 = p5;
+
+/**
  * A closure representing a p5 sketch in [Instance Mode](https://github.com/processing/p5.js/wiki/Global-and-instance-mode).
  *
  * Within the closure you can set optional `preload()`, `setup()`, and/or `draw()` properties on the given p5 instance.
  */
 export type Sketch = (sketch: p5) => void;
-
-/**
- * A p5 instance, re-exported from `@types/p5`.
- */
-export type p5 = p5;

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -6,3 +6,8 @@ import type p5 from 'p5';
  * Within the closure you can set optional `preload()`, `setup()`, and/or `draw()` properties on the given p5 instance.
  */
 export type Sketch = (sketch: p5) => void;
+
+/**
+ * A p5 instance, re-exported from `@types/p5`.
+ */
+export type p5 = p5;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -34,7 +34,7 @@
 					class="bg-p5/20 px-4 py-2 rounded 
 				{$page.url.pathname.startsWith('/docs')
 						? 'outline outline-1'
-						: 'hover:bg-white/20 hover:text-white'}">⫸ Get started</a
+						: 'hover:bg-white/20 hover:text-white'}">⫸ Docs</a
 				>
 			</li>
 

--- a/src/routes/docs/__layout.svelte
+++ b/src/routes/docs/__layout.svelte
@@ -7,6 +7,10 @@
 			title: '⫸ Get Started',
 			route: '/docs/get-started',
 		},
+		{
+			title: '↳ TypeScript',
+			route: '/docs/typescript',
+		},
 	];
 </script>
 

--- a/src/routes/docs/get-started.svelte
+++ b/src/routes/docs/get-started.svelte
@@ -1,5 +1,6 @@
-<script>
+<script lang="ts">
 	import P5 from '$lib/P5.svelte';
+	import type { Sketch } from '$lib';
 	import CodeBlock from '$components/CodeBlock.svelte';
 	import gettingStartedExample from '$helpers/gettingStartedExample';
 	import RangeSlider from 'svelte-range-slider-pips';
@@ -8,7 +9,7 @@
 	$: width = dimensions[0];
 	$: height = dimensions[1];
 
-	const sketch = (p5) => {
+	const sketch: Sketch = (p5) => {
 		p5.setup = () => {
 			p5.createCanvas(865, 400);
 		};

--- a/src/routes/docs/get-started.svelte
+++ b/src/routes/docs/get-started.svelte
@@ -20,8 +20,8 @@
 	};
 </script>
 
-<article id="get-started" class="flex flex-col space-y-3 max-w-[90ch]">
-	<h2 class="text-4xl pb-2">⫸ Get Started</h2>
+<article id="get-started" class="doc">
+	<h2 class="text-4xl">⫸ Get Started</h2>
 	<p>
 		Trying to get <a href="https://p5js.org/">p5</a> up and running in
 		<a href="https://svelte.dev">Svelte</a> can be a pain. So here's an absolutely dead simple way of
@@ -34,8 +34,8 @@
 		just as you would with regular Svelte! You can even have multiple p5 components per page without
 		any scoping issues!
 	</p>
-	<section id="installation" class="pt-3">
-		<h3 class="text-xl mb-3">Installation</h3>
+	<section id="installation">
+		<h3>Installation</h3>
 		<CodeBlock code="pnpm i p5-svelte" />
 		<p>
 			Depending on your environment, you may be alerted upon installing <code>p5-svelte</code> that
@@ -45,10 +45,10 @@
 		<CodeBlock code="pnpm i -D p5" />
 		<p>
 			Then import the exported <code>P5</code> component from <code>p5-svelte</code> into your desired
-			component:
+			component.
 		</p>
-		<section class="pt-3">
-			<h3 class="text-2xl text-p5">Code</h3>
+		<section>
+			<h3>Example</h3>
 			<CodeBlock code={gettingStartedExample} />
 		</section>
 		<h3 class="text-xl">Output</h3>
@@ -74,12 +74,3 @@
 		</div>
 	</section>
 </article>
-
-<style>
-	p {
-		@apply mb-3 opacity-90;
-	}
-	code {
-		@apply bg-gray-700 py-0.5 px-1 rounded;
-	}
-</style>

--- a/src/routes/docs/typescript.svelte
+++ b/src/routes/docs/typescript.svelte
@@ -26,7 +26,7 @@ export type Sketch = (sketch: p5) => void;`;
 	import P5 from 'p5-svelte';
 
 	/**
-	 * @type {import('package').Sketch}
+	 * @type {import('p5-svelte').Sketch}
 	 */
 	const sketch = (p5) => {
 		p5.setup = () => {

--- a/src/routes/docs/typescript.svelte
+++ b/src/routes/docs/typescript.svelte
@@ -3,8 +3,15 @@
 
 	const tsImportExample = `import type { Sketch } from 'p5-svelte';`;
 
-	const sketchType = `// p5-svelte/types.d.ts
+	const p5Type = `// p5-svelte/types.d.ts
 import type p5 from 'p5';
+
+/**
+ * A p5 instance, re-exported from \`@types/p5\`.
+ */
+export type p5 = p5;`;
+
+	const sketchType = `// p5-svelte/types.d.ts
 
 /**
  * A closure representing a p5 sketch in [Instance Mode](https://github.com/processing/p5.js/wiki/Global-and-instance-mode).
@@ -56,8 +63,19 @@ export type Sketch = (sketch: p5) => void;`;
 		<CodeBlock code={tsExampleSketch} isSketch lang="svelte-ts" />
 	</section>
 
-	<section id="sketch-type-def">
-		<h3>Sketch Type Definition</h3>
+	<section id="exposed-types">
+		<h3>Exposed Types</h3>
+
+		<h4 id="exposed-types-p5"><code>p5</code></h4>
+		<p>
+			We directly re-export the <code>p5</code> type so that you can use it in more advanced,
+			modular use-cases allowing direct access to the p5 instance type without needing to explicitly
+			install
+			<code>@types/p5</code>. This enables a single source of entry to p5.js.
+		</p>
+		<CodeBlock code={p5Type} lang="ts" />
+
+		<h4 id="exposed-types-sketch"><code>Sketch</code></h4>
 		<p>
 			For reference, here is the typedef under the hood - it's admittedly a simple passthrough to
 			the p5 type defs:

--- a/src/routes/docs/typescript.svelte
+++ b/src/routes/docs/typescript.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import CodeBlock from '$components/CodeBlock.svelte';
+
+	const tsImportExample = `import type { Sketch } from 'p5-svelte';`;
+
+	const sketchType = `// p5-svelte/types.d.ts
+import type p5 from 'p5';
+
+/**
+ * A closure representing a p5 sketch in [Instance Mode](https://github.com/processing/p5.js/wiki/Global-and-instance-mode).
+ *
+ * Within the closure you can set optional \`preload()\`, \`setup()\`, and/or \`draw()\` properties on the given p5 instance.
+ */
+export type Sketch = (sketch: p5) => void;`;
+
+	const tsExampleSketch = `(p5) => {
+		p5.setup = () => {
+			p5.createCanvas(p5.windowWidth, p5.windowHeight);
+		};
+		p5.draw = () => {
+			p5.ellipse(p5.width / 2, p5.height / 2, p5.width, p5.height);
+		};
+	}`;
+
+	const jsIntellisenseSketch = `<script>
+	import P5 from 'p5-svelte';
+
+	/**
+	 * @type {import('package').Sketch}
+	 */
+	const sketch = (p5) => {
+		p5.setup = () => {
+			p5.createCanvas(400, 400);
+		};
+		p5.draw = () => {
+			p5.background(255, 0, 0);
+		};
+	};
+\</\script>
+
+<P5 {sketch} />`;
+</script>
+
+<article id="TypeScript" class="doc">
+	<h2 class="text-4xl">↳ TypeScript</h2>
+	<p class="pb-3">
+		For better developer experience and type-safety while writing p5-svelte sketches, a <code
+			>Sketch</code
+		>
+		type is exposed from <code>p5-svelte</code>:
+	</p>
+	<CodeBlock code={tsImportExample} lang="ts" />
+
+	<section id="sketch-usage-example">
+		<h3>Sketch Usage Example</h3>
+		<CodeBlock code={tsExampleSketch} isSketch lang="svelte-ts" />
+	</section>
+
+	<section id="sketch-type-def">
+		<h3>Sketch Type Definition</h3>
+		<p>
+			For reference, here is the typedef under the hood - it's admittedly a simple passthrough to
+			the p5 type defs:
+		</p>
+		<CodeBlock code={sketchType} lang="ts" />
+	</section>
+
+	<section id="intellisense">
+		<h3>Intellisense</h3>
+		<p>
+			Not using TypeScript? No worries - you can leverage your IDE's intellisense with jsdoc type
+			hints:
+		</p>
+		<CodeBlock code={jsIntellisenseSketch} lang="ts" />
+	</section>
+</article>

--- a/src/routes/examples/3d.svelte
+++ b/src/routes/examples/3d.svelte
@@ -39,7 +39,7 @@
 	const sketchFunct = eval(sketch);
 </script>
 
-<article class="flex flex-col space-y-3">
+<article class="doc">
 	<h2 class="text-4xl">◎ 3D: Orbit Control</h2>
 	<p>Click and drag on the canvas for orbit control; it allows you to move around the world.</p>
 	<p>
@@ -51,7 +51,7 @@
 	<div class="border border-p5/40 rounded-md overflow-hidden">
 		<P5 sketch={sketchFunct} />
 	</div>
-	<section class="pt-3">
+	<section>
 		<h3 class="text-2xl text-p5">Code</h3>
 		<CodeBlock isSketch code={sketch} />
 	</section>

--- a/src/routes/examples/__layout.svelte
+++ b/src/routes/examples/__layout.svelte
@@ -19,10 +19,6 @@
 			title: '◎ 3D',
 			route: '/examples/3d',
 		},
-		// {
-		// 	title: 'Sound',
-		// 	route: '/examples/sound',
-		// },
 	];
 </script>
 

--- a/src/routes/examples/follow.svelte
+++ b/src/routes/examples/follow.svelte
@@ -48,11 +48,13 @@
 	const sketchFunct = eval(sketch);
 </script>
 
-<article class="flex flex-col space-y-3">
+<article class="doc">
 	<h2 class="text-4xl">↬ Follow</h2>
 	<p>
 		A segmented line follows the mouse. The relative angle from each segment to the next is
-		calculated with atan2() and the position of the next is calculated with sin() and cos().
+		calculated with <code>atan2()</code> and the position of the next is calculated with
+		<code>sin()</code>
+		and <code>cos()</code>.
 	</p>
 	<p>
 		Adapted from <a href="https://p5js.org/examples/interaction-follow-3.html" target="_blank"
@@ -63,7 +65,7 @@
 	<div class=" border border-p5/40 rounded-md overflow-hidden">
 		<P5 sketch={sketchFunct} />
 	</div>
-	<section class="pt-3">
+	<section>
 		<h3 class="text-2xl text-p5">Code</h3>
 		<CodeBlock isSketch code={sketch} />
 	</section>

--- a/src/routes/examples/index.svelte
+++ b/src/routes/examples/index.svelte
@@ -1,5 +1,5 @@
-<section>
-	<h1 class="text-4xl mb-6">Learn by Example</h1>
+<article class="doc">
+	<h1 class="text-4xl">Learn by Example</h1>
 	<p>
 		Explore the examples listed in the sidebar to your heart's content. These should serve as a
 		guide to using particular aspects of p5 in the context of this Svelte component.
@@ -9,10 +9,4 @@
 		Make sure to have fun and remind yourself how beautiful life can be. Kinda wild that we're all
 		minds in a body in this reality, goin' through it seperately but together.
 	</p>
-</section>
-
-<style>
-	p {
-		@apply mb-3 opacity-90;
-	}
-</style>
+</article>

--- a/src/routes/examples/mandelbrot-set.svelte
+++ b/src/routes/examples/mandelbrot-set.svelte
@@ -1,8 +1,0 @@
-<script>
-</script>
-
-The Mandelbrot Set
-
-<style>
-	/* your styles go here */
-</style>

--- a/src/routes/examples/sound.svelte
+++ b/src/routes/examples/sound.svelte
@@ -1,3 +1,0 @@
-<article class="flex flex-col space-y-3">
-	<h2 class="text-4xl">Sound</h2>
-</article>

--- a/src/routes/examples/vectors.svelte
+++ b/src/routes/examples/vectors.svelte
@@ -23,7 +23,7 @@
 	const sketchFunct = eval(sketch);
 </script>
 
-<article class="flex flex-col space-y-3">
+<article class="doc">
 	<h2 class="text-4xl">↗ Random Vectors</h2>
 	<p>
 		Adapted from Daniel Shiffman's <i>The Nature of Code</i>
@@ -36,7 +36,7 @@
 	<div class=" border border-p5/40 rounded-md overflow-hidden">
 		<P5 sketch={sketchFunct} />
 	</div>
-	<section class="pt-3">
+	<section>
 		<h3 class="text-2xl text-p5">Code</h3>
 		<CodeBlock isSketch code={sketch} />
 	</section>

--- a/src/routes/examples/wavemaker.svelte
+++ b/src/routes/examples/wavemaker.svelte
@@ -40,7 +40,7 @@
 	const sketchFunct = eval(sketch);
 </script>
 
-<article class="flex flex-col space-y-3">
+<article class="doc">
 	<h2 class="text-4xl">〰 Wavemaker</h2>
 	<p>
 		This illustrates how waves (like water waves) emerge from particles oscillating in place. Move
@@ -55,7 +55,7 @@
 	<div class=" border border-p5/40 rounded-md overflow-hidden">
 		<P5 sketch={sketchFunct} />
 	</div>
-	<section class="pt-3">
+	<section>
 		<h3 class="text-2xl text-p5">Code</h3>
 		<CodeBlock isSketch code={sketch} />
 	</section>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -89,11 +89,11 @@
 				</a>
 			</div>
 			<div
-				class="w-[600px] text-center text-p5"
+				class="w-[600px]"
 				style="--range-handle-focus:#ed225d; --range-handle:#ed225daa; --range-handle-inactive:#ed225d;--range-slider:#fff1"
 			>
 				<RangeSlider bind:values={branchHeight} min={40} max={260} float />
-				<p>Branch height</p>
+				<p class="font-mono text-center text-p5">Branch height</p>
 			</div>
 		</div>
 	</section>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
 	import P5 from '$lib/P5.svelte';
+	import type { Sketch } from '$lib/types';
 	import RangeSlider from 'svelte-range-slider-pips';
 
 	let branchHeight = [150];
 
-	const sketch = (p5) => {
-		let theta;
+	const sketch: Sketch = (p5) => {
+		let theta: number;
 
 		p5.setup = () => {
 			p5.createCanvas(1200, 800);
@@ -31,7 +32,7 @@
 			branch(branchHeight[0]);
 		};
 
-		function branch(h) {
+		function branch(h: number) {
 			// Each branch will be 2/3rds the size of the previous one
 			h *= 0.66;
 


### PR DESCRIPTION
A major pain-point while writing sketches with p5-svelte has been the lack of passthrough to p5's types. You and your editor were both flying blind. It was up to you to install and import p5's types - a bit of a clunky DX.

This PR integrates p5's types throughout the `<P5/>` component (+ the docs site 🖍️ ) and exposes a new `Sketch` type representing the p5 sketch in instance mode. This gives your editor prying eyes into p5's type system, supports autocomplete, and inline documentation of all the p5 goodies to make your life a little easier.

### 😤  Before

https://user-images.githubusercontent.com/43280336/161372626-32634e5b-37b1-4f56-b708-518200b1021f.mov

### 🧙‍♀️ After

https://user-images.githubusercontent.com/43280336/161373024-01c1a01d-b9ea-4ce4-8787-c42329a50ff6.mov

Here are the updated component props & their types:
```ts
// Component props
export let target: HTMLElement = undefined;
export let sketch: Sketch = undefined;
export let parentDivStyle: string = 'display: block;';
export let debug = false;
```

## Mildly breaking changes
- Removes `project` prop. Closes #124 
  - Will only affect strict CI/CD pipelines, doesn't actually break anything in the Svelte compiler or runtime.
  - Also niche and unlikely to affect users since this prop offered no utility.

## Doc updates
- A new page has been added to the `docs` section on TypeScript & Intellisense.
- Introduces a bit of renovation and TLC to the docs site to improve readability & styling DRYness. Closes #122 
- Lil typos and inconsistency fixes. Closes #121, #123
- New section in the README on valid component props