### PR TITLE
Fix missing exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,10 @@
 		"@types/p5": "^1.4.2"
 	},
 	"type": "module",
-	"svelte": "index.js"
+	"svelte": "index.js",
+	"exports": {
+		".": {
+			"svelte": "./index.js"
+		}
+	}
 }


### PR DESCRIPTION
When building a project with dependencies:

```
"@sveltejs/kit": "^2.0.0",
"@sveltejs/vite-plugin-svelte": "^3.0.0",
"svelte": "^4.2.3",
"vite": "^5.0.0",

"p5-svelte": "^3.1.2",
```

We get the following warning:

```
[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

p5-svelte@3.1.2
```

This MR reuses the example from the [doc for this error](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition) to fix the warning and ensure this lib won't break in the future.

> Using the svelte field in package.json to point at .svelte source files is deprecated and you must use a svelte [export condition](https://nodejs.org/api/packages.html#conditional-exports). vite-plugin-svelte 3 still resolves it as a fallback, but in a future major release this is going to be removed and without exports condition resolving the library is going to fail.

---

Btw thanks for this project it's super convenient :+1: 